### PR TITLE
Feature/publish hardlink

### DIFF
--- a/MipFingerprint.config
+++ b/MipFingerprint.config
@@ -21,7 +21,7 @@ process {
 
         publishDir {
             path = "$params.outdir/fastq_files"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -38,7 +38,7 @@ process {
 
         publishDir {
             path = "$params.outdir/bam_files"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -68,7 +68,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/FastQC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -79,7 +79,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC/Flagstat"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -90,7 +90,7 @@ process {
 
         publishDir {
             path = "$params.outdir/QC"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -101,7 +101,7 @@ process {
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 
@@ -112,7 +112,7 @@ process {
 
         publishDir {
             path = "$params.outdir/log"
-            mode = 'copy'
+            mode = 'link'
         }
     }
 

--- a/MipFingerprint.config
+++ b/MipFingerprint.config
@@ -56,8 +56,8 @@ process {
 
         publishDir = [
             [path: "$params.outdir/", mode: 'link', pattern: 'logbook.txt'],
-            [path: "$params.outdir/fingerprint/", mode: 'link', pattern: 'approvedVCFs/*.vcf', saveAs: { file -> file.split('/')[-1] }],
-            [path: "$params.outdir/fingerprint/", mode: 'link', pattern: 'disapprovedVCFs'],
+            [path: "$params.outdir/fingerprint/", mode: 'copy', pattern: 'approvedVCFs/*.vcf', saveAs: { file -> file.split('/')[-1] }],
+            [path: "$params.outdir/fingerprint/", mode: 'copy', pattern: 'disapprovedVCFs'],
         ]
     }
 

--- a/MipFingerprint.config
+++ b/MipFingerprint.config
@@ -55,9 +55,9 @@ process {
         time = '10m'
 
         publishDir = [
-            [path: "$params.outdir/", mode: 'copy', pattern: 'logbook.txt'],
-            [path: "$params.outdir/fingerprint/", mode: 'copy', pattern: 'approvedVCFs/*.vcf', saveAs: { file -> file.split('/')[-1] }],
-            [path: "$params.outdir/fingerprint/", mode: 'copy', pattern: 'disapprovedVCFs'],
+            [path: "$params.outdir/", mode: 'link', pattern: 'logbook.txt'],
+            [path: "$params.outdir/fingerprint/", mode: 'link', pattern: 'approvedVCFs/*.vcf', saveAs: { file -> file.split('/')[-1] }],
+            [path: "$params.outdir/fingerprint/", mode: 'link', pattern: 'disapprovedVCFs'],
         ]
     }
 


### PR DESCRIPTION
Set `publishDir` mode to `link` for all processes with a `publishDir` setting. Except for Fingerprint VCF files which are symlinks and should be copied.